### PR TITLE
Fix remove settings bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project uses the embedded database. It is recommended for production to mov
 Use the ***Deploy to Azure*** button above to deploy out an Azure App Service along with the additional files from this project. SonarQube may take up to 10 minutes to start the first time. This will deploy out a Basic (B1) App Service and have SQ use an in-memory database.
 
 ## Passthrough Application Settings
-You can set SonarQube sonar.properties and wrapper.conf settings based on the Azure application settings. Anything prefixed with sonar.* (for sonar.properties) and wrapper.* (for wrapper.conf) will at runtime be set in their respective files. This enables settings to be defined in the ARM template and set at runtime. An example of this is the Java runtime being set by the "wrapper.java.command" application setting.
+You can set SonarQube sonar.properties settings based on the Azure application settings. Anything prefixed with sonar.* will at runtime be set in sonar.properties file if it matches a property there. This enables settings to be defined in the ARM template and set at runtime.
 
 ## In-Depth Details
 After the ARM template is deployed a deployment script is executed to copy the wwwroot folder from the repository folder to the App Service wwwroot folder. It also finds the most recent release of SonarQube to download and extract into the App Service wwwroot folder.

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -90,8 +90,7 @@
                         "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "Deployment_Telemetry_Instrumentation_Key": "[variables('deploymentTelemetryKey')]",
-                        "wrapper.java.command": "%JAVA_HOME%\\bin\\java"
+                        "Deployment_Telemetry_Instrumentation_Key": "[variables('deploymentTelemetryKey')]"
                     }
                 },
                 {

--- a/wwwroot/HttpPlatformHandlerStartup.ps1
+++ b/wwwroot/HttpPlatformHandlerStartup.ps1
@@ -87,8 +87,8 @@ if(!$wrapperConfig) {
 
 log("File found at: $($wrapperConfig.FullName)")
 log("Writing to wrapper.conf file")	log('Updating wrapper.conf based on environment/application settings.')
-$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw	$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw
-$wrapperConfigContents -ireplace 'wrapper.java.command=java', "wrapper.java.command=%JAVA_HOME%\bin\java" | Set-Content -Path $wrapperConfig.FullName
+$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw
+$wrapperConfigContents -ireplace 'wrapper.java.command=java', 'wrapper.java.command=%JAVA_HOME%\bin\java' | Set-Content -Path $wrapperConfig.FullName
 
 log('Searching for StartSonar.bat')
 $startScript = Get-ChildItem 'StartSonar.bat' -Recurse

--- a/wwwroot/HttpPlatformHandlerStartup.ps1
+++ b/wwwroot/HttpPlatformHandlerStartup.ps1
@@ -82,16 +82,9 @@ if(!$wrapperConfig) {
 }
 
 log("File found at: $($wrapperConfig.FullName)")
-log('Updating wrapper.conf based on environment/application settings.')
-$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw
-Get-ChildItem Env: | Where-Object -Property Name -like -Value 'wrapper.*' | ForEach-Object {
-    $propertyName = $_.Name
-    $propertyValue = $_.Value
-    log("Setting $propertyName to $propertyValue")
-    $wrapperConfigContents = $wrapperConfigContents -ireplace "#?$propertyName=.*", "$propertyName=$propertyValue"
-}
-
-$wrapperConfigContents | Set-Content -Path $wrapperConfig.FullName
+log("Writing to wrapper.conf file")	log('Updating wrapper.conf based on environment/application settings.')
+$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw	$wrapperConfigContents = Get-Content -Path $wrapperConfig.FullName -Raw
+$wrapperConfigContents -ireplace 'wrapper.java.command=java', "wrapper.java.command=%JAVA_HOME%\bin\java" | Set-Content -Path $wrapperConfig.FullName
 
 log('Searching for StartSonar.bat')
 $startScript = Get-ChildItem 'StartSonar.bat' -Recurse

--- a/wwwroot/HttpPlatformHandlerStartup.ps1
+++ b/wwwroot/HttpPlatformHandlerStartup.ps1
@@ -57,8 +57,12 @@ if(!$propFile) {
     exit
 }
 log("File found at: $($propFile.FullName)")
-log('Updating sonar.properties based on environment/application settings.')
 $configContents = Get-Content -Path $propFile.FullName -Raw
+
+log('Resetting properties.')
+$configContents = $configContents -ireplace '#?sonar.', '#sonar.'
+
+log('Updating sonar.properties based on environment/application settings.')
 Get-ChildItem Env: | Where-Object -Property Name -like -Value 'sonar.*' | ForEach-Object {
     $propertyName = $_.Name
     $propertyValue = $_.Value


### PR DESCRIPTION
If you set an application setting then removed it the script would not remove it from sonar.properties.
I removed the use of wrapper settings since I didn't have a good solution to revert them if they were removed.