### PR TITLE
Update default version for SQ deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ This project uses the embedded database. It is recommended for production to mov
 
 ## Azure Clouds
 [Deploy to Azure Public Cloud](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fvanderby%2FSonarQube-AzureAppService%2Fmaster%2Fazuredeploy.json)  
-[Deploy to Azure US Government Cloud](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fvanderby%2FSonarQube-AzureAppService%2Fmaster%2Fazuredeploy.json)  
-[Deploy to Azure Germany Cloud](https://portal.microsoftazure.de/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fvanderby%2FSonarQube-AzureAppService%2Fmaster%2Fazuredeploy.json)  
+[Deploy to Azure US Government Cloud](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fvanderby%2FSonarQube-AzureAppService%2Fmaster%2Fazuredeploy.json)   
 [Deploy to Azure China Cloud](https://portal.azure.cn/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fvanderby%2FSonarQube-AzureAppService%2Fmaster%2Fazuredeploy.json)
 
 ## Getting Started

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -53,7 +53,7 @@
         },
         "SonarQube Version": {
             "type": "string",
-            "defaultValue": "Latest",
+            "defaultValue": "9.3.0.51899",
             "metadata": {
                 "description": "Specific version of SQ to download e.g. 7.9.1 or 8.0. Leave blank or set to 'Latest' for most recent version."
             }


### PR DESCRIPTION
* Update default version for SQ deployment
* Remove German cloud URL from readme since it is being shuttered.

Work around for #62 while a solution for specifying Latest is researched.