### PR TITLE
Pull Latest Version From GitHub

### DIFF
--- a/Deploy-SonarQubeAzureAppService.ps1
+++ b/Deploy-SonarQubeAzureAppService.ps1
@@ -80,26 +80,22 @@ TrackTimedEvent -InstrumentationKey $ApplicationInsightsApiKey -EventName 'Downl
     $downloadUri = ''
     $fileName = ''
     if(!$Version -or ($Version -ieq 'Latest')) {
-        $allDownloads = Invoke-WebRequest -Uri $downloadSource -UseBasicParsing
-        $zipFiles = $allDownloads[0].Links | Where-Object { $_.href.EndsWith('.zip') -and !($_.href.contains('alpha') -or $_.href.contains('RC')) }
-
-        # We sort by a custom expression so that we sort based on a version and not as a string. This results in the proper order given values such as 7.9.zip and 7.9.1.zip.
-        #   In the expression we use RegEx to find the "Version.zip" string, then split and grab the first to get just the "Version" and finally cast that to a version object
-        $sortedZipFiles = $zipFiles | Sort-Object -Property @{ Expression = { [Version]([RegEx]::Match($_.href, '\d+.\d+.?(\d+)?.?(\d+)?.zip').Value -Split ".zip")[0] } }
-        $latestFile = $sortedZipFiles[-1]
-        $downloadUri = "$downloadSource/$($latestFile.href)"
-        $fileName = $latestFile.href
-    } else {
-        $fileNamePart = 'sonarqube' # Community Edition
-        switch($Edition) {
-            'Developer' { $fileNamePart = 'sonarqube-developer' }
-            'Enterprise' { $fileNamePart = 'sonarqube-enterprise' }
-            'Data Center' { $fileNamePart = 'sonarqube-datacenter' }
-        }
-
-        $fileName = "$fileNamePart-$Version.zip"
-        $downloadUri = "$downloadSource/$fileName"
+        # binaries.sonarsource.com moved to S3 and is not easily searchable anymore. Getting the latest version from GitHub releases.
+        $releasesFromApi = (Invoke-WebRequest -Uri 'https://api.github.com/repos/SonarSource/sonarqube/releases' -UseBasicParsing).Content
+        $releasesPS = $releasesFromApi | ConvertFrom-Json
+        $Version = $releasesPS.Name | Sort-Object -Descending | Select-Object -First 1
+        Write-Output "Found the latest release to be $Version"
     }
+
+    $fileNamePart = 'sonarqube' # Community Edition
+    switch($Edition) {
+        'Developer' { $fileNamePart = 'sonarqube-developer' }
+        'Enterprise' { $fileNamePart = 'sonarqube-enterprise' }
+        'Data Center' { $fileNamePart = 'sonarqube-datacenter' }
+    }
+
+    $fileName = "$fileNamePart-$Version.zip"
+    $downloadUri = "$downloadSource/$fileName"
 
     if(!$downloadUri -or !$fileName) {
         throw 'Could not get download uri or filename.'

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -53,7 +53,7 @@
         },
         "SonarQube Version": {
             "type": "string",
-            "defaultValue": "9.3.0.51899",
+            "defaultValue": "Latest",
             "metadata": {
                 "description": "Specific version of SQ to download e.g. 7.9.1 or 8.0. Leave blank or set to 'Latest' for most recent version."
             }


### PR DESCRIPTION
Since the binaries site moved to S3 and is not easily searchable from PS, pull the latest version number from the releases of the GitHub repo. This fixes #62 