### PR TITLE
Fix HttpPlatformHandlerStartup.ps1 script

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,5 +1,34 @@
+Skip to content
+Search or jump to…
+Pull requests
+Issues
+Marketplace
+Explore
+ 
+@chiticariu 
+vanderby
+/
+SonarQube-AzureAppService
+Public
+Code
+Issues
+2
+Pull requests
+1
+Actions
+Security
+Insights
+SonarQube-AzureAppService/azuredeploy.json
+@akuryan
+akuryan Added more possible sizes to SQ hosting sizes (#68)
+Latest commit edb388d on Aug 5
+ History
+ 2 contributors
+@vanderby@akuryan
+139 lines (139 sloc)  4.72 KB
+
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "hostingPlanName": {
@@ -79,35 +108,17 @@
             }
         },
         {
-            "apiVersion": "2014-04-01",
-            "name": "[parameters('siteName')]",
-            "type": "Microsoft.Insights/components",
-            "location": "[resourceGroup().location]",
-            "tags": {
-              "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', parameters('siteName'))]": "Resource",
-              "displayName": "Application Function AppInsights",
-              "parent": "[parameters('siteName')]"
-            },
-            "properties": {
-              "applicationId": "[parameters('siteName')]"
-            }
-          },
-        {
             "apiVersion": "2016-08-01",
             "name": "[parameters('siteName')]",
             "type": "Microsoft.Web/sites",
             "location": "[parameters('siteLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]",
-                "[resourceId('microsoft.insights/components/', parameters('siteName'))]"
+                "[resourceId('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]",
                 "clientAffinityEnabled": false
-            },
-            "identity": {
-                "type": "SystemAssigned"
             },
             "resources": [
                 {
@@ -132,7 +143,6 @@
                         "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('siteName'))).InstrumentationKey]",
                         "Deployment_Telemetry_Instrumentation_Key": "[variables('deploymentTelemetryKey')]",
                         "SonarQubeEdition": "[parameters('SonarQube Edition')]",
                         "SonarQubeVersion": "[parameters('SonarQube Version')]"
@@ -156,3 +166,18 @@
         }
     ]
 }
+Footer
+© 2022 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+You have unread notifications

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -62,9 +62,6 @@
             }
         }
     },
-    "variables": {
-        "deploymentTelemetryKey": "e15aa4db-a1cc-4622-844f-e7dd01596983"
-    },
     "resources": [
         {
             "apiVersion": "2016-09-01",
@@ -79,17 +76,35 @@
             }
         },
         {
+            "apiVersion": "2014-04-01",
+            "name": "[parameters('siteName')]",
+            "type": "Microsoft.Insights/components",
+            "location": "[resourceGroup().location]",
+            "tags": {
+              "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', parameters('siteName'))]": "Resource",
+              "displayName": "Application Function AppInsights",
+              "parent": "[parameters('siteName')]"
+            },
+            "properties": {
+              "applicationId": "[parameters('siteName')]"
+            }
+          },
+        {
             "apiVersion": "2016-08-01",
             "name": "[parameters('siteName')]",
             "type": "Microsoft.Web/sites",
             "location": "[parameters('siteLocation')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]",
+                "[resourceId('microsoft.insights/components/', parameters('siteName'))]"
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]",
                 "clientAffinityEnabled": false
+            },
+            "identity": {
+                "type": "SystemAssigned"
             },
             "resources": [
                 {
@@ -114,7 +129,7 @@
                         "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "Deployment_Telemetry_Instrumentation_Key": "[variables('deploymentTelemetryKey')]",
+                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('siteName'))).InstrumentationKey]",
                         "SonarQubeEdition": "[parameters('SonarQube Edition')]",
                         "SonarQubeVersion": "[parameters('SonarQube Version')]"
                     }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,32 +1,3 @@
-Skip to content
-Search or jump to…
-Pull requests
-Issues
-Marketplace
-Explore
- 
-@chiticariu 
-vanderby
-/
-SonarQube-AzureAppService
-Public
-Code
-Issues
-2
-Pull requests
-1
-Actions
-Security
-Insights
-SonarQube-AzureAppService/azuredeploy.json
-@akuryan
-akuryan Added more possible sizes to SQ hosting sizes (#68)
-Latest commit edb388d on Aug 5
- History
- 2 contributors
-@vanderby@akuryan
-139 lines (139 sloc)  4.72 KB
-
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
@@ -166,18 +137,3 @@ Latest commit edb388d on Aug 5
         }
     ]
 }
-Footer
-© 2022 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About
-You have unread notifications

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "hostingPlanName": {
@@ -61,6 +61,9 @@
                 "description": "Specific version of SQ to download e.g. 7.9.1 or 8.0. Leave blank or set to 'Latest' for most recent version."
             }
         }
+    },
+    "variables": {
+        "deploymentTelemetryKey": "e15aa4db-a1cc-4622-844f-e7dd01596983"
     },
     "resources": [
         {
@@ -130,6 +133,7 @@
                     ],
                     "properties": {
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('microsoft.insights/components/', parameters('siteName'))).InstrumentationKey]",
+                        "Deployment_Telemetry_Instrumentation_Key": "[variables('deploymentTelemetryKey')]",
                         "SonarQubeEdition": "[parameters('SonarQube Edition')]",
                         "SonarQubeVersion": "[parameters('SonarQube Version')]"
                     }

--- a/wwwroot/HttpPlatformHandlerStartup.ps1
+++ b/wwwroot/HttpPlatformHandlerStartup.ps1
@@ -1,5 +1,5 @@
 ﻿param(
-    [string]$ApplicationInsightsApiKey = $Env:APPINSIGHTS_INSTRUMENTATIONKEY
+    [string]$ApplicationInsightsApiKey = $Env:Deployment_Telemetry_Instrumentation_Key
 )
 
 function log($message) {


### PR DESCRIPTION
This fix a part from issue #54 regarding sonar.properties transformation, and other issues related to configuration key identification and replacement, that breaks the sonarqube starting process (a configuration key, for example sonar.jdbc.url, will be uncommented and with the same value 4 times)

I've extended the arm template with application insight deployment as well, so that the script HttpPlatformHandlerStartup.ps1 will log events to this instance without manual intervention.