### PR TITLE
Update Java version to fix CGI error

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -101,7 +101,7 @@
                     ],
                     "properties": {
                         "alwaysOn": false,
-                        "javaVersion": "11",
+                        "javaVersion": "17",
                         "javaContainer": "TOMCAT",
                         "javaContainerVersion": "9.0"
                     }


### PR DESCRIPTION
I was getting the error mentioned on issue #75 on a new deploy and noticed when manually running StartSonar.bat that I got an error requesting to use Java 17.  Updated the Java Version and it works now.